### PR TITLE
tech(basepath): set basepath for the app

### DIFF
--- a/react/src/App.js
+++ b/react/src/App.js
@@ -15,7 +15,7 @@ function App() {
   return (
       <ErrorHandler>
         <PageLoader />
-        <Router history={browserHistory}>
+        <Router history={browserHistory} basename="/slack-app-clone-web/react">
           <Routes />
         </Router>
       </ErrorHandler>

--- a/react/webpack.config.js
+++ b/react/webpack.config.js
@@ -59,6 +59,7 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, "public"),
+    publicPath:'/slack-app-clone-web/react',
     filename: "slack-clone.js",
     chunkFilename: "[name].js",
   },
@@ -89,7 +90,7 @@ module.exports = {
     }),
   ],
   devServer: {
-    open: true,
+    open: ['/slack-app-clone-web/react'],
     historyApiFallback: true,
     static: {
       directory: "./src/static",


### PR DESCRIPTION
Set base path for react app as per the git directory structure.

`/slack-app-clone-web/react`

to automatically start the dev server with basepath included basepath in `devServer` object's `open` property