### PR TITLE
build(basepath): fix github actions

### DIFF
--- a/react/webpack.config.js
+++ b/react/webpack.config.js
@@ -58,7 +58,7 @@ module.exports = {
     },
   },
   output: {
-    path: path.resolve(__dirname, "public"),
+    path: path.resolve(__dirname, "../public"),
     publicPath:'/slack-app-clone-web/react',
     filename: "slack-clone.js",
     chunkFilename: "[name].js",


### PR DESCRIPTION
Fix GitHub public directory.

During the build process, GitHub action will have an output directory outside the react folder so have changed the output.path to the parent directory.